### PR TITLE
PHP v7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - 7.0
-  - 7.1
+  - '7.1'
+  - '7.2'
+  - '7.3'
 
 before_script: composer install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Package name changed to `maxemail/api-php`
 - Namespaces have been changed from `Emailcenter\MaxemailApi` to
   `Maxemail\Api`. Sorry.
+### Removed
+- Removed support for PHP 7.0 as it is no longer
+[actively supported](https://php.net/supported-versions.php) by the PHP project
+
 
 ## [4.0.1] - 2017-08-21
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Self-contained client in PHP for simplifying access to the Maxemail API
 
 ## Requirements
 
-![PHP](https://img.shields.io/badge/php-%5E7.0-brightgreen.svg)
+![PHP](https://img.shields.io/badge/php-%5E7.1-brightgreen.svg)
 
-This package requires PHP 7.x . Please see previous releases if you
+This package requires at least PHP 7.1 . Please see previous releases if you
 require compatibility with an older version of PHP.
 
 Composer will verify any other environment requirements on install/update.

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 
     "require-dev": {
         "phlib/logger": "^3.0",
-        "phpunit/phpunit" : "^6.2",
+        "phpunit/phpunit" : "^7",
         "php-mock/php-mock-phpunit": "^2.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
 
     "require": {
-        "php" : "^7.0",
+        "php" : "^7.1",
         "ext-fileinfo": "*",
         "ext-json" : "*",
         "ext-zip": "*",

--- a/src/Client.php
+++ b/src/Client.php
@@ -235,7 +235,7 @@ class Client implements \Psr\Log\LoggerAwareInterface
      * @param \Psr\Log\LoggerInterface $logger
      * @return $this
      */
-    public function setLogger(\Psr\Log\LoggerInterface $logger)
+    public function setLogger(\Psr\Log\LoggerInterface $logger): self
     {
         $this->logger = $logger;
 

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -47,7 +47,7 @@ class Helper
      * @param string $level
      * @return $this
      */
-    public function setLogLevel(string $level)
+    public function setLogLevel(string $level): self
     {
         $this->logLevel = $level;
 

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -24,9 +24,10 @@ class Middleware
     /**
      * @see https://michaelstivala.com/logging-guzzle-requests/
      * @param HandlerStack $stack
+     * @param LoggerInterface $logger
      * @return void
      */
-    public static function addLogging(HandlerStack $stack, LoggerInterface $logger)
+    public static function addLogging(HandlerStack $stack, LoggerInterface $logger): void
     {
         $messageFormats = [
             '{method}: {uri} HTTP/{version} {req_body}', // request
@@ -51,8 +52,9 @@ class Middleware
      *
      * @param HandlerStack $stack
      * @param LoggerInterface $logger
+     * @return void
      */
-    public static function addWarningLogging(HandlerStack $stack, LoggerInterface $logger)
+    public static function addWarningLogging(HandlerStack $stack, LoggerInterface $logger): void
     {
         $middleware = GuzzleMiddleware::mapResponse(function (ResponseInterface $response) use ($logger) {
             if ($response->hasHeader('Warning')) {
@@ -78,8 +80,9 @@ class Middleware
     /**
      * Add parser for Maxemail 4xx-level errors
      * @param HandlerStack $stack
+     * @return void
      */
-    public static function addMaxemailErrorParser(HandlerStack $stack)
+    public static function addMaxemailErrorParser(HandlerStack $stack): void
     {
         $middleware = GuzzleMiddleware::mapResponse(function (ResponseInterface $response) {
             $code = $response->getStatusCode();


### PR DESCRIPTION
With package namespace changes in master, we'll be bumping major version. This gives an opportunity to drop php70 as it's no longer actively supported, and take advantage of php71 features and dependency updates.