### PR TITLE
Update Maxemail default URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Default Maxemail URI changed to `https://mxm.xtremepush.com/`. This will
+  only affect implementations using the default URI but with no impact, as the
+  old and new domains resolve to the same Maxemail instance.
 
 ## [4.0.1] - 2017-08-21
 ### Changed

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
     <php>
         <!-- Configuration to enable functional tests -->
         <var name="FUNC_ENABLED" value="false" />
-        <var name="FUNC_API_URI" value="https://maxemail.emailcenteruk.com/" />
+        <var name="FUNC_API_URI" value="https://mxm.xtremepush.com/" />
         <var name="FUNC_API_USERNAME" value="api@user.com" />
         <var name="FUNC_API_PASSWORD" value="apipass" />
     </php>

--- a/src/Client.php
+++ b/src/Client.php
@@ -61,7 +61,7 @@ class Client implements \Psr\Log\LoggerAwareInterface
     /**
      * @var string
      */
-    private $uri = 'https://maxemail.emailcenteruk.com/';
+    private $uri = 'https://mxm.xtremepush.com/';
 
     /**
      * @var string
@@ -102,7 +102,7 @@ class Client implements \Psr\Log\LoggerAwareInterface
      * @param array $config {
      *     @var string $username     Required
      *     @var string $password     Required
-     *     @var string $uri          Optional. Default https://maxemail.emailcenteruk.com/
+     *     @var string $uri          Optional. Default https://mxm.xtremepush.com/
      *     @var string $user         @deprecated See username
      *     @var string $pass         @deprecated See password
      *     @var bool   $debugLogging Optional. Enable logging of request/response. Default false

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -42,7 +42,7 @@ class ApiTest extends TestCase
 
         $api = new Client($config);
 
-        $this->assertEquals('https://maxemail.emailcenteruk.com/', $api->getConfig()['uri']);
+        $this->assertEquals('https://mxm.xtremepush.com/', $api->getConfig()['uri']);
     }
 
     public function testConfigStripsUriPath()


### PR DESCRIPTION
Update to use the new Xtremepush domain, which resolves to the same Maxemail instance.

This change to merge into a 4.x branch and release as a new minor version, eg. 4.1