### PR TITLE
Drop legacy config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add PHP 8 type declarations.
 ### Removed
+- Remove deprecated config options for `user` and `pass`.
 - **BC break**: Removed support for PHP versions <= v8.0 as they are no longer
   [actively supported](https://php.net/supported-versions.php) by the PHP project.
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -85,21 +85,11 @@ class Client implements LoggerAwareInterface
      *     username: string, // Required
      *     password: string, // Required
      *     uri: string, // Optional. Default https://mxm.xtremepush.com/
-     *     user: string, // @deprecated See username
-     *     pass: string, // @deprecated See password
      *     debugLogging: bool, // Optional. Enable logging of request/response. Default false
      * } $config
      */
     public function __construct(array $config)
     {
-        // Support deprecated key names from v3
-        if (!isset($config['username']) && isset($config['user'])) {
-            $config['username'] = $config['user'];
-        }
-        if (!isset($config['password']) && isset($config['pass'])) {
-            $config['password'] = $config['pass'];
-        }
-
         // Must have user/pass
         if (!isset($config['username']) || !isset($config['password'])) {
             throw new Exception\InvalidArgumentException('API config requires username & password');

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -29,19 +29,6 @@ class ApiTest extends TestCase
         static::assertSame($this->testConfig, $api->getConfig());
     }
 
-    public function testConfigSupportDeprecatedUserPass(): void
-    {
-        $config = [
-            'user' => 'api@user.com',
-            'pass' => 'apipass',
-        ];
-
-        $api = new Client($config);
-
-        static::assertSame($config['user'], $api->getConfig()['username']);
-        static::assertSame($config['pass'], $api->getConfig()['password']);
-    }
-
     public function testConfigDefaultHost(): void
     {
         $config = [


### PR DESCRIPTION
- Remove deprecated config options for `user` and `pass`