### PR TITLE
Token authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Support for API token authentication. Username and password can still be used
+  as a fallback.
+### Changed
+- Deprecate `getConfig()` method. Packages can maintain their config internally.
 
 ## [6.0.0] - 2025-02-14
 ### Added
@@ -13,6 +18,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Remove deprecated config options for `user` and `pass`.
 - **BC break**: Removed support for PHP versions <= v8.0 as they are no longer
   [actively supported](https://php.net/supported-versions.php) by the PHP project.
+
+## [5.2.0] - 2025-06-25
+### Added
+- Support for API token authentication. Username and password can still be used
+  as a fallback.
+### Changed
+- Deprecate `getConfig()` method. Packages can maintain their config internally.
 
 ## [5.1.1] - 2021-08-10
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ $ composer require maxemail/api-php
 ```php
 // Instantiate Client:
 $config = [
-    'username' => 'api@user.com',
-    'password' => 'apipass'
+    'token' => 'apitoken',
 ];
 $api = new \Maxemail\Api\Client($config);
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,8 +12,7 @@
         <!-- Configuration to enable functional tests -->
         <env name="FUNC_ENABLED" value="false" />
         <env name="FUNC_API_URI" value="https://mxm.xtremepush.com/" />
-        <env name="FUNC_API_USERNAME" value="api@user.com" />
-        <env name="FUNC_API_PASSWORD" value="apipass" />
+        <env name="FUNC_API_TOKEN" value="apitoken" />
     </php>
 
     <testsuites>

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Maxemail\Api;
 
-use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\ClientInterface as GuzzleClient;
 use Psr\Log\LogLevel;
 
 /**

--- a/src/Service.php
+++ b/src/Service.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Maxemail\Api;
 
-use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\ClientInterface as GuzzleClient;
 
 /**
  * Maxemail API Client

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Maxemail\Api;
 
+use GuzzleHttp\ClientInterface as GuzzleClient;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -18,40 +19,75 @@ class ClientTest extends TestCase
 {
     private array $testConfig = [
         'uri' => 'https://maxemail.example.com/',
-        'username' => 'api@user.com',
-        'password' => 'apipass',
+        'token' => 'apitoken',
     ];
 
     public function testConfigValid(): void
     {
         $api = new Client($this->testConfig);
 
-        static::assertSame($this->testConfig, $api->getConfig());
+        $factory = function (array $actual): GuzzleClient {
+            $expectedUri = $this->testConfig['uri'] . 'api/json/';
+            static::assertSame($expectedUri, $actual['base_uri']);
+
+            $expectedHeaders = [
+                'User-Agent' => 'MxmApiClient/' . Client::VERSION . ' PHP/' . PHP_VERSION,
+                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer ' . $this->testConfig['token'],
+            ];
+            static::assertSame($expectedHeaders, $actual['headers']);
+
+            return $this->createMock(GuzzleClient::class);
+        };
+
+        $api->setHttpClientFactory($factory);
+
+        // Get a service, to trigger the HTTP Client factory
+        $api->folder;
     }
 
     public function testConfigDefaultHost(): void
     {
         $config = [
-            'username' => 'api@user.com',
-            'password' => 'apipass',
+            'token' => 'apitoken',
         ];
 
         $api = new Client($config);
 
-        static::assertSame('https://mxm.xtremepush.com/', $api->getConfig()['uri']);
+        $factory = function (array $actual) use ($config): GuzzleClient {
+            $expectedUri = 'https://mxm.xtremepush.com/api/json/';
+            static::assertSame($expectedUri, $actual['base_uri']);
+
+            return $this->createMock(GuzzleClient::class);
+        };
+
+        $api->setHttpClientFactory($factory);
+
+        // Get a service, to trigger the HTTP Client factory
+        $api->folder;
     }
 
     public function testConfigStripsUriPath(): void
     {
         $config = [
-            'uri' => 'http://maxemail.example.com/some/extra/path',
-            'username' => 'api@user.com',
-            'password' => 'apipass',
+            'uri' => 'https://maxemail.example.com/some/extra/path',
+            'token' => 'apitoken',
         ];
 
         $api = new Client($config);
 
-        static::assertSame('http://maxemail.example.com/', $api->getConfig()['uri']);
+        $factory = function (array $actual) use ($config): GuzzleClient {
+            $expectedUri = 'https://maxemail.example.com/api/json/';
+            static::assertSame($expectedUri, $actual['base_uri']);
+
+            return $this->createMock(GuzzleClient::class);
+        };
+
+        $api->setHttpClientFactory($factory);
+
+        // Get a service, to trigger the HTTP Client factory
+        $api->folder;
     }
 
     public function testConfigInvalidUri(): void
@@ -61,8 +97,7 @@ class ClientTest extends TestCase
 
         $config = [
             'uri' => '//',
-            'username' => 'api@user.com',
-            'password' => 'apipass',
+            'token' => 'apitoken',
         ];
 
         new Client($config);
@@ -75,17 +110,49 @@ class ClientTest extends TestCase
 
         $config = [
             'uri' => 'maxemail.example.com',
-            'username' => 'api@user.com',
-            'password' => 'apipass',
+            'token' => 'apitoken',
         ];
 
         new Client($config);
     }
 
+    public function testConfigLegacyAuthentication(): void
+    {
+        $config = [
+            'username' => 'api@user.com',
+            'password' => 'apipass',
+        ];
+
+        $api = new Client($config);
+
+        $factory = function (array $actual) use ($config): GuzzleClient {
+            $expectedAuth = [
+                $config['username'],
+                $config['password'],
+            ];
+            static::assertSame($expectedAuth, $actual['auth']);
+
+            return $this->createMock(GuzzleClient::class);
+        };
+
+        $api->setHttpClientFactory($factory);
+
+        // Get a service, to trigger the HTTP Client factory
+        $api->folder;
+    }
+
+    public function testConfigMissingToken(): void
+    {
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('API config requires token OR username & password');
+
+        new Client([]);
+    }
+
     public function testConfigMissingUsername(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('API config requires username & password');
+        $this->expectExceptionMessage('API config requires token OR username & password');
 
         $config = [
             'password' => 'apipass',
@@ -97,13 +164,39 @@ class ClientTest extends TestCase
     public function testConfigMissingPassword(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('API config requires username & password');
+        $this->expectExceptionMessage('API config requires token OR username & password');
 
         $config = [
             'username' => 'api@user.com',
         ];
 
         new Client($config);
+    }
+
+    public function testGetConfigWithToken(): void
+    {
+        $api = new Client($this->testConfig);
+
+        $expected = [
+            'uri' => $this->testConfig['uri'],
+            'username' => null,
+            'password' => null,
+        ];
+
+        static::assertSame($expected, $api->getConfig());
+    }
+
+    public function testGetConfigWithLegacyAuthentication(): void
+    {
+        $config = [
+            'uri' => 'https://maxemail.example.com/',
+            'username' => 'api@user.com',
+            'password' => 'apipass',
+        ];
+
+        $api = new Client($config);
+
+        static::assertSame($config, $api->getConfig());
     }
 
     public function testSetGetLogger(): void

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -27,8 +27,7 @@ class FunctionalTest extends TestCase
 
         $config = [
             'uri' => getenv('FUNC_API_URI'),
-            'username' => getenv('FUNC_API_USERNAME'),
-            'password' => getenv('FUNC_API_PASSWORD'),
+            'token' => getenv('FUNC_API_TOKEN'),
         ];
         $this->client = new Client($config);
     }


### PR DESCRIPTION
Merging `v5.x` back to `main`, from #18 .

- Add support for token authentication for Maxemail v145.