### PR TITLE
Revert token authentication 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Revert support for token auth, added in v5.2.0.
 
 ## [5.2.0] - 2025-06-25
 ### Added
-- Support for API token authentication. Username and password can still be used
-  as a fallback.
+- ~~Support for API token authentication. Username and password can still be used
+  as a fallback.~~ Reverted in v5.2.1.
 ### Changed
 - Deprecate `getConfig()` method. Packages can maintain their config internally.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Revert support for token auth, added in v5.2.0.
+- Label username and password for clientId and clientSecret. No param changes.
 
 ## [5.2.0] - 2025-06-25
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ $ composer require maxemail/api-php
 ```php
 // Instantiate Client:
 $config = [
-    'username' => 'api@user.com',
-    'password' => 'apipass'
+    'username' => 'client ID',
+    'password' => 'client secret'
 ];
 $api = new \Maxemail\Api\Client($config);
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ $ composer require maxemail/api-php
 ```php
 // Instantiate Client:
 $config = [
-    'token' => 'apitoken',
+    'username' => 'api@user.com',
+    'password' => 'apipass'
 ];
 $api = new \Maxemail\Api\Client($config);
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,8 @@
         <!-- Configuration to enable functional tests -->
         <env name="FUNC_ENABLED" value="false" />
         <env name="FUNC_API_URI" value="https://mxm.xtremepush.com/" />
-        <env name="FUNC_API_TOKEN" value="apitoken" />
+        <env name="FUNC_API_USERNAME" value="api@user.com" />
+        <env name="FUNC_API_PASSWORD" value="apipass" />
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,8 +12,8 @@
         <!-- Configuration to enable functional tests -->
         <env name="FUNC_ENABLED" value="false" />
         <env name="FUNC_API_URI" value="https://mxm.xtremepush.com/" />
-        <env name="FUNC_API_USERNAME" value="api@user.com" />
-        <env name="FUNC_API_PASSWORD" value="apipass" />
+        <env name="FUNC_API_USERNAME" value="clientId" />
+        <env name="FUNC_API_PASSWORD" value="clientSecret" />
     </php>
 
     <testsuites>

--- a/src/Client.php
+++ b/src/Client.php
@@ -108,8 +108,8 @@ class Client implements \Psr\Log\LoggerAwareInterface
 
     /**
      * @param array $config {
-     *     @var string $username     Required
-     *     @var string $password     Required
+     *     @var string $username     Required; API client ID
+     *     @var string $password     Required; API client secret
      *     @var string $uri          Optional. Default https://mxm.xtremepush.com/
      *     @var string $user         @deprecated See username
      *     @var string $pass         @deprecated See password

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -19,8 +19,8 @@ class ClientTest extends TestCase
 {
     private $testConfig = [
         'uri' => 'https://maxemail.example.com/',
-        'username' => 'api@user.com',
-        'password' => 'apipass',
+        'username' => 'clientId',
+        'password' => 'clientSecret',
     ];
 
     public function testConfigValid()
@@ -81,8 +81,8 @@ class ClientTest extends TestCase
     public function testConfigDefaultHost()
     {
         $config = [
-            'username' => 'api@user.com',
-            'password' => 'apipass',
+            'username' => 'clientId',
+            'password' => 'clientSecret',
         ];
 
         $api = new Client($config);
@@ -104,8 +104,8 @@ class ClientTest extends TestCase
     {
         $config = [
             'uri' => 'https://maxemail.example.com/some/extra/path',
-            'username' => 'api@user.com',
-            'password' => 'apipass',
+            'username' => 'clientId',
+            'password' => 'clientSecret',
         ];
 
         $api = new Client($config);
@@ -130,8 +130,8 @@ class ClientTest extends TestCase
 
         $config = [
             'uri' => '//',
-            'username' => 'api@user.com',
-            'password' => 'apipass',
+            'username' => 'clientId',
+            'password' => 'clientSecret',
         ];
 
         new Client($config);
@@ -144,8 +144,8 @@ class ClientTest extends TestCase
 
         $config = [
             'uri' => 'maxemail.example.com',
-            'username' => 'api@user.com',
-            'password' => 'apipass',
+            'username' => 'clientId',
+            'password' => 'clientSecret',
         ];
 
         new Client($config);
@@ -157,7 +157,7 @@ class ClientTest extends TestCase
         $this->expectExceptionMessage('API config requires username & password');
 
         $config = [
-            'password' => 'apipass',
+            'password' => 'clientSecret',
         ];
 
         new Client($config);
@@ -169,7 +169,7 @@ class ClientTest extends TestCase
         $this->expectExceptionMessage('API config requires username & password');
 
         $config = [
-            'username' => 'api@user.com',
+            'username' => 'clientId',
         ];
 
         new Client($config);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -19,7 +19,8 @@ class ClientTest extends TestCase
 {
     private $testConfig = [
         'uri' => 'https://maxemail.example.com/',
-        'token' => 'apitoken',
+        'username' => 'api@user.com',
+        'password' => 'apipass',
     ];
 
     public function testConfigValid()
@@ -30,11 +31,16 @@ class ClientTest extends TestCase
             $expectedUri = $this->testConfig['uri'] . 'api/json/';
             static::assertSame($expectedUri, $actual['base_uri']);
 
+            $expectedAuth = [
+                $this->testConfig['username'],
+                $this->testConfig['password'],
+            ];
+            static::assertSame($expectedAuth, $actual['auth']);
+
             $expectedHeaders = [
                 'User-Agent' => 'MxmApiClient/' . Client::VERSION . ' PHP/' . PHP_VERSION,
                 'Content-Type' => 'application/x-www-form-urlencoded',
                 'Accept' => 'application/json',
-                'Authorization' => 'Bearer ' . $this->testConfig['token'],
             ];
             static::assertSame($expectedHeaders, $actual['headers']);
 
@@ -75,7 +81,8 @@ class ClientTest extends TestCase
     public function testConfigDefaultHost()
     {
         $config = [
-            'token' => 'apitoken',
+            'username' => 'api@user.com',
+            'password' => 'apipass',
         ];
 
         $api = new Client($config);
@@ -97,7 +104,8 @@ class ClientTest extends TestCase
     {
         $config = [
             'uri' => 'https://maxemail.example.com/some/extra/path',
-            'token' => 'apitoken',
+            'username' => 'api@user.com',
+            'password' => 'apipass',
         ];
 
         $api = new Client($config);
@@ -122,7 +130,8 @@ class ClientTest extends TestCase
 
         $config = [
             'uri' => '//',
-            'token' => 'apitoken',
+            'username' => 'api@user.com',
+            'password' => 'apipass',
         ];
 
         new Client($config);
@@ -135,49 +144,17 @@ class ClientTest extends TestCase
 
         $config = [
             'uri' => 'maxemail.example.com',
-            'token' => 'apitoken',
+            'username' => 'api@user.com',
+            'password' => 'apipass',
         ];
 
         new Client($config);
     }
 
-    public function testConfigLegacyAuthentication(): void
-    {
-        $config = [
-            'username' => 'api@user.com',
-            'password' => 'apipass',
-        ];
-
-        $api = new Client($config);
-
-        $factory = function (array $actual) use ($config): GuzzleClient {
-            $expectedAuth = [
-                $config['username'],
-                $config['password'],
-            ];
-            static::assertSame($expectedAuth, $actual['auth']);
-
-            return $this->createMock(GuzzleClient::class);
-        };
-
-        $api->setHttpClientFactory($factory);
-
-        // Get a service, to trigger the HTTP Client factory
-        $api->folder;
-    }
-
-    public function testConfigMissingToken(): void
-    {
-        $this->expectException(Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('API config requires token OR username & password');
-
-        new Client([]);
-    }
-
     public function testConfigMissingUsername(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('API config requires token OR username & password');
+        $this->expectExceptionMessage('API config requires username & password');
 
         $config = [
             'password' => 'apipass',
@@ -189,7 +166,7 @@ class ClientTest extends TestCase
     public function testConfigMissingPassword(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('API config requires token OR username & password');
+        $this->expectExceptionMessage('API config requires username & password');
 
         $config = [
             'username' => 'api@user.com',
@@ -198,30 +175,11 @@ class ClientTest extends TestCase
         new Client($config);
     }
 
-    public function testGetConfigWithToken(): void
+    public function testGetConfig(): void
     {
         $api = new Client($this->testConfig);
 
-        $expected = [
-            'uri' => $this->testConfig['uri'],
-            'username' => null,
-            'password' => null,
-        ];
-
-        static::assertSame($expected, $api->getConfig());
-    }
-
-    public function testGetConfigWithLegacyAuthentication(): void
-    {
-        $config = [
-            'uri' => 'https://maxemail.example.com/',
-            'username' => 'api@user.com',
-            'password' => 'apipass',
-        ];
-
-        $api = new Client($config);
-
-        static::assertSame($config, $api->getConfig());
+        static::assertSame($this->testConfig, $api->getConfig());
     }
 
     public function testSetGetLogger()

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -30,7 +30,8 @@ class FunctionalTest extends TestCase
 
         $config = [
             'uri' => getenv('FUNC_API_URI'),
-            'token' => getenv('FUNC_API_TOKEN'),
+            'username' => getenv('FUNC_API_USERNAME'),
+            'password' => getenv('FUNC_API_PASSWORD'),
         ];
         $this->client = new Client($config);
     }


### PR DESCRIPTION
Revert the token authentication changes added in #18 , keeping the deprecation for `getConfig()`.

Although this is essentially a BC break as it removes code, no implementation can have used token auth as it is not live in the Maxemail app.